### PR TITLE
Add optional install for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-jupyter-book
-matplotlib
-numpy
-tomli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ dev = [
 ]
 pulser = ["pulser == 1.4.0"]
 myqlm = ["numpy == 1.26.4", "myqlm == 1.11.3"]
+docs = [
+    "sphinx",
+    "sphinx-autoapi",
+    "jupyter_book",
+    "tomli",
+]
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
Now you can install sphinx + other docs requirements with
```
pip install -e ".[docs]"
```
or
```
pip install ".[docs]"
```
if you don't want to be in editable mode.
