### PR TITLE
Remove print from MyQLM module

### DIFF
--- a/qse/calc/myqlm.py
+++ b/qse/calc/myqlm.py
@@ -43,24 +43,9 @@ else:
     else:
         AQPU = None
 
-if qat_available:
-    print("qat is available")
-else:
-    print("qat is not available")
-if qlmaas_available:
-    print("qlmaas is available")
-else:
-    print("qlmaas is not available")
-print(AQPU)
-
 from time import time
 
 import qse.magnetic as magnetic
-
-# analogQPU imported based on what's available
-
-
-# from qat.core.variables import Variable, heaviside
 
 try:
     import qat


### PR DESCRIPTION
Currently
```
qat is not available
qlmaas is not available
None
```
is printed everytime `qse` is imported. 

This PR removes these lines.