### PR TITLE
Only generate docs when merging to master

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Issue: https://github.com/ICHEC/qse/issues/116

Generating the docs when not merging to main is unnecessary. Here the Git actions are updated to only generate the docs when merging to main.