### PR TITLE
Refactor qbits - distances, angles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "James Nelson", email = "james.nelson@ichec.ie"},
     {name = "Sherry Blair", email = "sherry.blair@ichec.ie"}
     ]
-version = "0.2.13"
+version = "0.2.14"
 requires-python = ">=3.10"
 dependencies = [
     "ase",

--- a/qse/qbits.py
+++ b/qse/qbits.py
@@ -1342,18 +1342,16 @@ class Qbits:
         np.ndarray
             An array containing the distances.
         """
-        return np.array(
-            [np.linalg.norm(self.positions[i] - self.positions[j]) for j in indices]
-        )
+        return np.array([self.get_distance(i, j) for j in indices])
 
     def get_all_distances(self):
         """
-        Return the distances of all of the qbits with all of the qubits.
+        Return the distances of all of the qubits with all of the other qubits.
 
         Returns
         -------
         np.ndarray
-            An array containing the distances.
+            An array of shape (nqbits, nqbits) containing the distances.
         """
         distances = np.zeros((self.nqbits, self.nqbits))
         for i in range(self.nqbits - 1):

--- a/qse/qbits.py
+++ b/qse/qbits.py
@@ -1219,20 +1219,20 @@ class Qbits:
 
         Parameters
         ----------
-        i : int
-            The index of the first qubit.
+        i : list | np.ndarray
+            The indices of the groupings of qubits.
+            Must be 
 
         Returns
         -------
         np.ndarray
+            The angles between the qubits.
 
         Notes
         -----
         Let x1, x2, x3 be the vectors describing the positions of the three
-        qubits. Then we calcule the angle between x1-x2 and x3-x2.
-
-        Calculate angle in degrees between vectors between qbits a2->a1
-        and a2->a3, where a1, a2, and a3 are in each row of indices.
+        qubits. Then we calcule the angle between x1-x2 and x3-x2 for all the
+        different groupings.
         """
         indices = np.array(indices)
         assert indices.shape[1] == 3

--- a/qse/qbits.py
+++ b/qse/qbits.py
@@ -1219,9 +1219,9 @@ class Qbits:
 
         Parameters
         ----------
-        i : list | np.ndarray
+        indices : list | np.ndarray
             The indices of the groupings of qubits.
-            Must be 
+            Must be of shape (n, 3), where n is the number of groupings.
 
         Returns
         -------
@@ -1235,7 +1235,8 @@ class Qbits:
         different groupings.
         """
         indices = np.array(indices)
-        assert indices.shape[1] == 3
+        if indices.shape[1] != 3:
+            raise Exception("The indicies must be of shape (-1, 3).")
 
         a1s = self.positions[indices[:, 0]]
         a2s = self.positions[indices[:, 1]]

--- a/tests/qse/qbits_methods_test.py
+++ b/tests/qse/qbits_methods_test.py
@@ -307,7 +307,7 @@ def test_euler_rotate_distances(phi, theta, psi, center):
     assert np.allclose(qbits.get_all_distances(), distances)
 
 
-@pytest.mark.parametrize("angle", [90, 36.0])
+@pytest.mark.parametrize("angle", [-44, -15.99, 5, 10, 36.9, 90, 180.0, 299.0])
 def test_get_angle(angle):
     """Test get_angle on a simple 3-qbit system."""
     angle_rads = np.pi * angle / 180
@@ -319,14 +319,13 @@ def test_get_angle(angle):
         ]
     )
     qbits = qse.Qbits(positions=positions)
-    assert np.isclose(qbits.get_angle(0, 1, 2), angle)
+    qbits.translate(10 * np.random.rand())  # random displacement
+    qbits.euler_rotate(*(360 * np.random.rand(3)))  # random global rotation
 
-    # Angle should be invariant under global translation.
-    qbits.translate(-3.3)
-    assert np.isclose(qbits.get_angle(0, 1, 2), angle)
-
-    # Angle should be invariant under global rotation.
-    qbits.euler_rotate(10, 20, -44.5)
+    if angle > 180.0:
+        angle = 360.0 - angle
+    if angle < 0.0:
+        angle = -angle
     assert np.isclose(qbits.get_angle(0, 1, 2), angle)
 
 

--- a/tests/qse/qbits_methods_test.py
+++ b/tests/qse/qbits_methods_test.py
@@ -44,6 +44,31 @@ def test_add_qbit():
     assert all(qbits.labels == [1, 2, 3, "q"])
 
 
+@pytest.mark.parametrize("nqbits", [2, 3, 4])
+def test_get_distance(nqbits):
+    """Test get_distance on a set of qbits."""
+    positions = np.random.rand(nqbits, 3)
+    qbits = qse.Qbits(positions=positions)
+
+    assert qbits.nqbits == positions.shape[0]
+
+    d = np.sqrt(((positions[0] - positions[1]) ** 2).sum())
+    assert np.isclose(qbits.get_distance(0, 1), d)
+
+
+@pytest.mark.parametrize("nqbits", [2, 3, 4])
+def test_get_distances(nqbits):
+    """Test get_distances on a set of qbits."""
+    positions = np.random.rand(nqbits, 3)
+    qbits = qse.Qbits(positions=positions)
+
+    assert qbits.nqbits == positions.shape[0]
+    inds = list(range(nqbits))
+    d = np.sqrt(((positions[0] - positions) ** 2).sum(1))
+    assert np.isclose(d[0], 0.0)
+    assert np.allclose(qbits.get_distances(0, inds), d)
+
+
 def test_get_all_distances():
     """Test get_all_distances on a simple set of qbits."""
     positions = np.array(
@@ -67,6 +92,16 @@ def test_get_all_distances():
     )
 
     assert np.allclose(qbits.get_all_distances(), distances)
+
+
+@pytest.mark.parametrize("nqbits", [2, 3, 4])
+def test_get_all_distances_properties(nqbits):
+    """Test the properties of get_all_distances."""
+    qbits = qse.Qbits(positions=np.random.rand(nqbits, 3))
+    distances = qbits.get_all_distances()
+    assert distances.shape == (nqbits, nqbits)
+    assert all(0.0 == i for i in np.diag(distances))
+    assert np.allclose(distances, distances.T)
 
 
 @pytest.mark.parametrize(

--- a/tests/qse/qbits_methods_test.py
+++ b/tests/qse/qbits_methods_test.py
@@ -6,7 +6,7 @@ import qse
 
 def _qbits_checker(qbits, positions, total_qubits):
     assert isinstance(qbits, qse.Qbits)
-    assert np.allclose(qbits.get_positions(), positions)
+    assert np.allclose(qbits.positions, positions)
     assert qbits.nqbits == total_qubits
 
 
@@ -107,8 +107,8 @@ def test_rattle(nqbits):
     qbits = qse.Qbits(positions=positions)
     qbits.rattle()
 
-    assert qbits.get_positions().shape == positions.shape
-    assert not np.allclose(qbits.get_positions(), positions)
+    assert qbits.positions.shape == positions.shape
+    assert not np.allclose(qbits.positions, positions)
 
 
 @pytest.mark.parametrize("nqbits", [1, 2, 3, 10])
@@ -134,7 +134,7 @@ def test_translate(nqbits, type_of_disp):
             qbits.translate(disp)
     else:
         qbits.translate(disp)
-        assert np.allclose(qbits.get_positions(), positions + disp)
+        assert np.allclose(qbits.positions, positions + disp)
 
 
 def test_get_item():
@@ -150,11 +150,11 @@ def test_get_item():
     # test list
     for indices in [[0, 2], [1, 3, 2]]:
         assert isinstance(qbits[indices], qse.Qbits)
-        assert np.allclose(qbits[indices].get_positions(), positions[indices])
+        assert np.allclose(qbits[indices].positions, positions[indices])
 
     # test slice
     assert isinstance(qbits[1:3], qse.Qbits)
-    assert np.allclose(qbits[1:3].get_positions(), positions[1:3])
+    assert np.allclose(qbits[1:3].positions, positions[1:3])
 
 
 @pytest.mark.parametrize("indices", [1, [0, 1, 3]])
@@ -184,12 +184,12 @@ def test_rotate():
     qbits = qse.Qbits(positions=unit_square)
     qbits.rotate(90, "z")
 
-    assert not np.allclose(qbits.get_positions(), unit_square)
+    assert not np.allclose(qbits.positions, unit_square)
 
     unit_square_rt = np.array(
         [[0.0, 1.0, 0.0], [-1.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
     )
-    assert np.allclose(qbits.get_positions(), unit_square_rt)
+    assert np.allclose(qbits.positions, unit_square_rt)
 
     # Check that a centered square is invariant (with relabelling).
     square_centered = np.array(
@@ -197,7 +197,7 @@ def test_rotate():
     )
     qbits = qse.Qbits(positions=square_centered)
     qbits.rotate(90, "z")
-    assert np.allclose(qbits.get_positions(), square_centered[[2, 0, 3, 1]])
+    assert np.allclose(qbits.positions, square_centered[[2, 0, 3, 1]])
 
 
 @pytest.mark.parametrize("angle", [10, 20, 30])
@@ -223,7 +223,7 @@ def test_rotate_square_z(angle, axis):
             [np.cos(angle_rads), np.sin(angle_rads), 1.0],
         ]
     )
-    assert np.allclose(qbits.get_positions(), new_positions)
+    assert np.allclose(qbits.positions, new_positions)
 
 
 @pytest.mark.parametrize("a", ["x", "-y", (0.0, 2.0, 3)])
@@ -237,7 +237,7 @@ def test_rotate_distances(a, v, center):
 
     qbits.rotate(a, v, center)
 
-    assert not np.allclose(qbits.get_positions(), positions)
+    assert not np.allclose(qbits.positions, positions)
     assert np.allclose(qbits.get_all_distances(), distances)
 
 
@@ -253,7 +253,7 @@ def test_euler_rotate_and_rotate():
     qbits_2 = qse.Qbits(positions=positions)
     qbits_2.euler_rotate(-34)
 
-    assert np.allclose(qbits_1.get_positions(), qbits_2.get_positions())
+    assert np.allclose(qbits_1.positions, qbits_2.positions)
 
 
 @pytest.mark.parametrize("phi", [11.2, 45.0])
@@ -268,7 +268,7 @@ def test_euler_rotate_distances(phi, theta, psi, center):
 
     qbits.euler_rotate(phi, theta, psi, center)
 
-    assert not np.allclose(qbits.get_positions(), positions)
+    assert not np.allclose(qbits.positions, positions)
     assert np.allclose(qbits.get_all_distances(), distances)
 
 


### PR DESCRIPTION
Here we:
- Remove `set_positions` and `get_positions`, this functionality is already present just use `positions`
- I've removed scaled from the centroid functions
- renamed the indices (i,j,k) for get_angle, ...
- Add more tests for the distance functions