### PR TITLE
removed the version changing part, as a dedicated github action does it

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -72,23 +72,22 @@ if [ $?  -ne 0 ]; then
   exit 1
 fi
 
-version=`grep version pyproject.toml`
-read -r major minor patch <<<$(echo $version|sed 's/=/\n/g'|tail -1|sed 's/"//g'|tr '.' ' ')
-new_version="version = \"$major.$minor.$[patch+1]\""
+# version=`grep version pyproject.toml`
+# read -r major minor patch <<<$(echo $version|sed 's/=/\n/g'|tail -1|sed 's/"//g'|tr '.' ' ')
+# new_version="version = \"$major.$minor.$[patch+1]\""
+# 
+# echo "Incrementing patch number: old -> $version new -> $new_version"
+# echo "updating pyproject.toml"
+# 
+# sed -i '' -e "s/$version/$new_version/g" pyproject.toml
+# 
+# if [ $? -ne 0 ]; then
+#     echo "error updating patch number!"
+#     exit 1
+# fi
+# committing pyproject change before push!"
+# git commit -m "changed $(grep version pyproject.toml)" pyproject.toml
 
-echo "Incrementing patch number: old -> $version new -> $new_version"
-echo "updating pyproject.toml"
-
-sed -i '' -e "s/$version/$new_version/g" pyproject.toml
-
-if [ $? -ne 0 ]; then
-    echo "error updating patch number!"
-    exit 1
-fi
-
-echo "All checks passed. Ready to push. committing pyproject change before push!"
-
-git commit -m "changed $(grep version pyproject.toml)" pyproject.toml
-
+echo "All checks passed. Ready to push!"
 
 exit 0


### PR DESCRIPTION
We can merge it quickly. It just removes the version changing part of the hooks, which is better done at the github action level.