### PR TITLE
Format with updated version of black

### DIFF
--- a/examples/pulser-myqlm-conversion.ipynb
+++ b/examples/pulser-myqlm-conversion.ipynb
@@ -109,7 +109,6 @@
    "source": [
     "import qse.qbits\n",
     "\n",
-    "\n",
     "L = 3\n",
     "nqbits = L * L\n",
     "qsqr = qse.Qbits(positions=np.array([[0, 0, 0]]))\n",
@@ -351,7 +350,6 @@
    "source": [
     "import qse.qbits\n",
     "\n",
-    "\n",
     "L = 3\n",
     "nqbits = L * L\n",
     "qsqr = qse.Qbits(positions=np.array([[0, 0, 0]]))\n",
@@ -581,7 +579,6 @@
    "source": [
     "import qse.qbits\n",
     "\n",
-    "\n",
     "L = 3\n",
     "nqbits = L * L\n",
     "qsqr = qse.Qbits(positions=np.array([[0, 0, 0]]))\n",
@@ -809,7 +806,6 @@
    "outputs": [],
    "source": [
     "import qse.qbits\n",
-    "\n",
     "\n",
     "L = 3\n",
     "nqbits = L * L\n",
@@ -1054,7 +1050,6 @@
    "outputs": [],
    "source": [
     "import qse.qbits\n",
-    "\n",
     "\n",
     "L = 3\n",
     "nqbits = L * L\n",
@@ -1404,7 +1399,6 @@
    "outputs": [],
    "source": [
     "import qse.qbits\n",
-    "\n",
     "\n",
     "L = 3\n",
     "nqbits = L * L\n",
@@ -1756,7 +1750,6 @@
    "outputs": [],
    "source": [
     "import qse.qbits\n",
-    "\n",
     "\n",
     "L = 3\n",
     "nqbits = L * L\n",


### PR DESCRIPTION
black recently had a new release (https://github.com/psf/black/releases/tag/26.1.0) version 26.1.0.
One change in this release is to force one blank line after import statements, this was causing problems in the `pulser-myqlm-conversion.ipynb` notebook where we sometimes had two lines between import statements