### PR TITLE
265 add visualizer for scalar quantities

### DIFF
--- a/qse/vis/__init__.py
+++ b/qse/vis/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "bar",
     "draw_amp_and_det",
     "draw_qbits",
+    "draw_scalar",
     "draw_signal",
     "view_matrix",
     "qse_green",
@@ -22,6 +23,6 @@ __all__ = [
 ]
 from qse.vis.colours import qse_green, qse_red
 from qse.vis.qbits import draw_qbits
+from qse.vis.scalar import draw_scalar
 from qse.vis.signal import draw_amp_and_det, draw_signal
 from qse.vis.visualise import bar, view_matrix
-from qse.vis.scalar import draw_scalar

--- a/qse/vis/__init__.py
+++ b/qse/vis/__init__.py
@@ -15,7 +15,7 @@ __all__ = [
     "bar",
     "draw_amp_and_det",
     "draw_qbits",
-    "draw_scalar",
+    "qbits_heatmap",
     "draw_signal",
     "view_matrix",
     "qse_green",
@@ -23,6 +23,6 @@ __all__ = [
 ]
 from qse.vis.colours import qse_green, qse_red
 from qse.vis.qbits import draw_qbits
-from qse.vis.scalar import draw_scalar
+from qse.vis.scalar import qbits_heatmap
 from qse.vis.signal import draw_amp_and_det, draw_signal
 from qse.vis.visualise import bar, view_matrix

--- a/qse/vis/__init__.py
+++ b/qse/vis/__init__.py
@@ -24,3 +24,4 @@ from qse.vis.colours import qse_green, qse_red
 from qse.vis.qbits import draw_qbits
 from qse.vis.signal import draw_amp_and_det, draw_signal
 from qse.vis.visualise import bar, view_matrix
+from qse.vis.scalar import draw_scalar

--- a/qse/vis/scalar.py
+++ b/qse/vis/scalar.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def draw_scalar(qbits, scalar, radius=None, show_labels=False, units=None):
+def qbits_heatmap(qbits, scalar, radius=None, show_labels=False, units=None):
     """
     Visualize the positions of a set of qubits with some scalar quantity.
 
@@ -12,7 +12,8 @@ def draw_scalar(qbits, scalar, radius=None, show_labels=False, units=None):
     qbits: qse.Qbits
         The Qbits object.
     scalar: list | np.ndarray
-        Must have the same length as the number of Qubits.
+        The scalar quantity to define the heatmap.
+        Must have the same length as the number of qubits.
     radius: float | str
         A cutoff radius for visualizing bonds.
         Pass 'nearest' to set the radius to the smallest

--- a/qse/vis/scalar.py
+++ b/qse/vis/scalar.py
@@ -1,6 +1,6 @@
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-import matplotlib as mpl
 
 
 def draw_scalar(qbits, scalar, radius=None, show_labels=False, units=None):
@@ -67,7 +67,6 @@ def draw_scalar(qbits, scalar, radius=None, show_labels=False, units=None):
         for i, j in neighbours:
             alpha = (min_dist / rij[i, j]) ** 3
             ax.plot([x[i], x[j]], [y[i], y[j]], c="gray", alpha=alpha, zorder=-1)
-
 
     ax.scatter(x, y, c="k", s=110, alpha=0.5)
     scatter = ax.scatter(x, y, c=scalar, s=100, cmap=mpl.colormaps["Blues"])

--- a/qse/vis/scalar.py
+++ b/qse/vis/scalar.py
@@ -1,0 +1,78 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib as mpl
+
+
+def draw_scalar(qbits, scalar, radius=None, show_labels=False, units=None):
+    """
+    Visualize the positions of a set of qubits with some scalar quantity.
+
+    Parameters
+    ----------
+    qbits: qse.Qbits
+        The Qbits object.
+    scalar: list | np.ndarray
+        Must have the same length as the number of Qubits.
+    radius: float | str
+        A cutoff radius for visualizing bonds.
+        Pass 'nearest' to set the radius to the smallest
+        distance between the passed qubits.
+        If no value is passed the bonds will not be visualized.
+    show_labels: bool
+        Whether to show the labels of the qubits.
+        Defaults to False.
+    units : str, optional
+        The units of distance.
+    """
+    if len(scalar) != qbits.nqbits:
+        raise Exception("The length of scalar must equal the number of Qubits.")
+
+    draw_bonds = False if radius is None else True
+    rij = None
+    min_dist = None
+
+    if draw_bonds:
+        rij = qbits.get_all_distances()
+        min_dist = rij[np.logical_not(np.eye(qbits.nqbits, dtype=bool))].min()
+        if radius == "nearest":
+            radius = min_dist
+        elif min_dist > radius:
+            draw_bonds = False
+
+    fig = plt.figure()
+    ax = fig.add_subplot()
+
+    ax.set_xlabel("x" + f" ({units})" if units is not None else "x")
+
+    if qbits.dim == 2:
+        x, y = qbits.positions.T
+        ax.set_ylabel("y" + f" ({units})" if units is not None else "y")
+        ax.set_aspect("equal")
+
+    else:
+        x = qbits.positions.T.flatten()
+        y = np.zeros(qbits.nqbits)
+        ax.set_yticks([])  # remove y-ticks for 1d plot.
+
+    if draw_bonds:
+        f_tol = 1.01  # fractional tolerance
+        neighbours = np.array(
+            [
+                (i, j)
+                for i in range(qbits.nqbits - 1)
+                for j in range(i + 1, qbits.nqbits)
+                if rij[i, j] <= radius * f_tol
+            ]
+        )
+        for i, j in neighbours:
+            alpha = (min_dist / rij[i, j]) ** 3
+            ax.plot([x[i], x[j]], [y[i], y[j]], c="gray", alpha=alpha, zorder=-1)
+
+
+    ax.scatter(x, y, c="k", s=110, alpha=0.5)
+    scatter = ax.scatter(x, y, c=scalar, s=100, cmap=mpl.colormaps["Blues"])
+    fig.colorbar(scatter)
+
+    if show_labels:
+        for ind in range(qbits.nqbits):
+            ax.text(x[ind], y[ind], s=qbits.labels[ind])

--- a/uv.lock
+++ b/uv.lock
@@ -4444,7 +4444,7 @@ wheels = [
 
 [[package]]
 name = "qse"
-version = "1.1.19"
+version = "1.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Adds a function to visualize scalar quantities: 

E.g.

```
qse.vis.qbits_heatmap(qbits, densities[-1][0], radius="nearest")
```

<img width="538" height="389" alt="image" src="https://github.com/user-attachments/assets/a57674b9-90d9-4a54-b04c-05264711af9b" />
